### PR TITLE
upgrade for python3.11

### DIFF
--- a/urllib3_mock.py
+++ b/urllib3_mock.py
@@ -40,15 +40,15 @@ __all__ = ['Responses']
 
 
 def get_wrapped(func, wrapper_template, evaldict):
-    # Preserve the argspec for the wrapped function so that testing
-    # tools such as pytest can continue to use their fixture injection.
-    args, a, kw, defaults = inspect.getargspec(func)
+    signature = inspect.signature(func)
 
-    signature = inspect.formatargspec(args, a, kw, defaults)
     is_bound_method = hasattr(func, '__self__')
     if is_bound_method:
         args = args[1:]     # Omit 'self'
-    callargs = inspect.formatargspec(args, a, kw, None)
+    callargs = inspect.Signature(parameters=[
+        inspect.Parameter(name=name, kind=inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        for name in signature.parameters
+    ])
 
     ctx = {'signature': signature, 'funcargs': callargs}
     _exec(wrapper_template % ctx, evaldict)


### PR DESCRIPTION
Feel free not to merge this, but for anyone that wants to upgrade to the Signature method that was added in python3.5.